### PR TITLE
Add unit testing from appsody

### DIFF
--- a/pkg/controller/runtimeapplication/runtimeapplication_controller_test.go
+++ b/pkg/controller/runtimeapplication/runtimeapplication_controller_test.go
@@ -1,0 +1,335 @@
+package runtimeapplication
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+
+	runtimeappv1beta1 "github.com/application-runtimes/operator/pkg/apis/runtimeapp/v1beta1"
+	runtimeapputils "github.com/application-runtimes/operator/pkg/utils"
+	prometheusv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	certmngrv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	coretesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var (
+	name                       = "app"
+	namespace                  = "runtimeapp"
+	appImage                   = "my-image"
+	ksvcAppImage               = "ksvc-image"
+	replicas             int32 = 3
+	autoscaling                = &runtimeappv1beta1.RuntimeApplicationAutoScaling{MaxReplicas: 3}
+	pullPolicy                 = corev1.PullAlways
+	serviceType                = corev1.ServiceTypeClusterIP
+	service                    = &runtimeappv1beta1.RuntimeApplicationService{Type: &serviceType, Port: 8080}
+	expose                     = true
+	serviceAccountName         = "service-account"
+	volumeCT                   = &corev1.PersistentVolumeClaim{TypeMeta: metav1.TypeMeta{Kind: "StatefulSet"}}
+	storage                    = runtimeappv1beta1.RuntimeApplicationStorage{Size: "10Mi", MountPath: "/mnt/data", VolumeClaimTemplate: volumeCT}
+	createKnativeService       = true
+	statefulSetSN              = name + "-headless"
+)
+
+type Test struct {
+	test     string
+	expected interface{}
+	actual   interface{}
+}
+
+func TestRuntimeController(t *testing.T) {
+	// Set the logger to development mode for verbose logs
+	logf.SetLogger(logf.ZapLogger(true))
+	os.Setenv("WATCH_NAMESPACE", namespace)
+
+	spec := runtimeappv1beta1.RuntimeApplicationSpec{}
+	runtimeapp := createRuntimeApp(name, namespace, spec)
+
+	// Set objects to track in the fake client and register operator types with the runtime scheme.
+	objs, s := []runtime.Object{runtimeapp}, scheme.Scheme
+
+	// Add third party resrouces to scheme
+	if err := servingv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add servingv1alpha1 scheme: (%v)", err)
+	}
+
+	if err := routev1.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add route scheme: (%v)", err)
+	}
+
+	if err := certmngrv1alpha2.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add cert-manager scheme: (%v)", err)
+	}
+
+	if err := prometheusv1.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add prometheus scheme: (%v)", err)
+	}
+
+	s.AddKnownTypes(runtimeappv1beta1.SchemeGroupVersion, runtimeapp)
+	s.AddKnownTypes(certmngrv1alpha2.SchemeGroupVersion, &certmngrv1alpha2.Certificate{})
+	s.AddKnownTypes(prometheusv1.SchemeGroupVersion, &prometheusv1.ServiceMonitor{})
+
+	// Create a fake client to mock API calls.
+	cl := fakeclient.NewFakeClient(objs...)
+
+	rb := runtimeapputils.NewReconcilerBase(cl, s, &rest.Config{}, record.NewFakeRecorder(10))
+
+	// Create a ReconcileRuntimeApplication object
+	r := &ReconcileRuntimeApplication{ReconcilerBase: rb}
+	r.SetDiscoveryClient(createFakeDiscoveryClient())
+
+	// Mock request to simulate Reconcile being called on an event for a watched resource
+	// then ensure reconcile is successful and does not return an empty result
+	req := createReconcileRequest(name, namespace)
+	res, err := r.Reconcile(req)
+	verifyReconcile(res, err, t)
+
+	// Check if deployment has been created
+	dep := &appsv1.Deployment{}
+	if err = r.GetClient().Get(context.TODO(), req.NamespacedName, dep); err != nil {
+		t.Fatalf("Get Deployment: (%v)", err)
+	}
+
+	depTests := []Test{
+		{"service account name", "app", dep.Spec.Template.Spec.ServiceAccountName},
+	}
+	verifyTests("dep", depTests, t)
+
+	// Update runtimeapp with values for StatefulSet
+	// Update ServiceAccountName for empty case
+	runtimeapp.Spec = runtimeappv1beta1.RuntimeApplicationSpec{
+		Storage:          &storage,
+		Replicas:         &replicas,
+		ApplicationImage: appImage,
+	}
+	updateRuntimeApp(r, runtimeapp, t)
+
+	// Reconcile again to check for the StatefulSet and updated resources
+	res, err = r.Reconcile(req)
+	verifyReconcile(res, err, t)
+
+	// Check if StatefulSet has been created
+	statefulSet := &appsv1.StatefulSet{}
+	if err = r.GetClient().Get(context.TODO(), req.NamespacedName, statefulSet); err != nil {
+		t.Fatalf("Get StatefulSet: (%v)", err)
+	}
+
+	// Storage is enabled so the deployment should be deleted
+	if err = r.GetClient().Get(context.TODO(), req.NamespacedName, dep); err == nil {
+		t.Fatalf("Deployment was not deleted")
+	}
+
+	// Check updated values in StatefulSet
+	ssTests := []Test{
+		{"replicas", replicas, *statefulSet.Spec.Replicas},
+		{"service image name", appImage, statefulSet.Spec.Template.Spec.Containers[0].Image},
+		{"pull policy", name, statefulSet.Spec.Template.Spec.ServiceAccountName},
+		{"service account name", statefulSetSN, statefulSet.Spec.ServiceName},
+	}
+	verifyTests("statefulSet", ssTests, t)
+
+	// Enable CreateKnativeService
+	runtimeapp.Spec = runtimeappv1beta1.RuntimeApplicationSpec{
+		CreateKnativeService: &createKnativeService,
+		PullPolicy:           &pullPolicy,
+		ApplicationImage:     ksvcAppImage,
+	}
+	updateRuntimeApp(r, runtimeapp, t)
+
+	// Reconcile again to check for the KNativeService and updated resources
+	res, err = r.Reconcile(req)
+	verifyReconcile(res, err, t)
+
+	// Create KnativeService
+	ksvc := &servingv1alpha1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "serving.knative.dev/v1alpha1",
+			Kind:       "Service",
+		},
+	}
+	if err = r.GetClient().Get(context.TODO(), req.NamespacedName, ksvc); err != nil {
+		t.Fatalf("Get KnativeService: (%v)", err)
+	}
+
+	// KnativeService is enabled so non-Knative resources should be deleted
+	if err = r.GetClient().Get(context.TODO(), req.NamespacedName, statefulSet); err == nil {
+		t.Fatalf("StatefulSet was not deleted")
+	}
+
+	// Check updated values in KnativeService
+	ksvcTests := []Test{
+		{"service image name", ksvcAppImage, ksvc.Spec.Template.Spec.Containers[0].Image},
+		{"pull policy", pullPolicy, ksvc.Spec.Template.Spec.Containers[0].ImagePullPolicy},
+		{"service account name", name, ksvc.Spec.Template.Spec.ServiceAccountName},
+	}
+	verifyTests("ksvc", ksvcTests, t)
+
+	// Disable Knative and enable Expose to test route
+	runtimeapp.Spec = runtimeappv1beta1.RuntimeApplicationSpec{Expose: &expose}
+	updateRuntimeApp(r, runtimeapp, t)
+
+	// Reconcile again to check for the route and updated resources
+	res, err = r.Reconcile(req)
+	verifyReconcile(res, err, t)
+
+	// Create Route
+	route := &routev1.Route{
+		TypeMeta: metav1.TypeMeta{APIVersion: "route.openshift.io/v1", Kind: "Route"},
+	}
+	if err = r.GetClient().Get(context.TODO(), req.NamespacedName, route); err != nil {
+		t.Fatalf("Get Route: (%v)", err)
+	}
+
+	// Check updated values in Route
+	routeTests := []Test{{"target port", intstr.FromString(strconv.Itoa(int(service.Port)) + "-tcp"), route.Spec.Port.TargetPort}}
+	verifyTests("route", routeTests, t)
+
+	// Disable Route/Expose and enable Autoscaling
+	runtimeapp.Spec = runtimeappv1beta1.RuntimeApplicationSpec{
+		Autoscaling: autoscaling,
+	}
+	updateRuntimeApp(r, runtimeapp, t)
+
+	// Reconcile again to check for hpa and updated resources
+	res, err = r.Reconcile(req)
+	verifyReconcile(res, err, t)
+
+	// Create HorizontalPodAutoscaler
+	hpa := &autoscalingv1.HorizontalPodAutoscaler{}
+	if err = r.GetClient().Get(context.TODO(), req.NamespacedName, hpa); err != nil {
+		t.Fatalf("Get HPA: (%v)", err)
+	}
+
+	// Expose is disabled so route should be deleted
+	if err = r.GetClient().Get(context.TODO(), req.NamespacedName, route); err == nil {
+		t.Fatal("Route was not deleted")
+	}
+
+	// Check updated values in hpa
+	hpaTests := []Test{{"max replicas", autoscaling.MaxReplicas, hpa.Spec.MaxReplicas}}
+	verifyTests("hpa", hpaTests, t)
+
+	// Remove autoscaling to ensure hpa is deleted
+	runtimeapp.Spec.Autoscaling = nil
+	updateRuntimeApp(r, runtimeapp, t)
+
+	res, err = r.Reconcile(req)
+	verifyReconcile(res, err, t)
+
+	// Autoscaling is disabled so hpa should be deleted
+	if err = r.GetClient().Get(context.TODO(), req.NamespacedName, hpa); err == nil {
+		t.Fatal("hpa was not deleted")
+	}
+
+	if err = r.GetClient().Get(context.TODO(), req.NamespacedName, runtimeapp); err != nil {
+		t.Fatalf("Get runtimeapp: (%v)", err)
+	}
+
+	// Update runtimeapp to ensure it requeues
+	runtimeapp.SetGeneration(1)
+	updateRuntimeApp(r, runtimeapp, t)
+
+	res, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+}
+
+
+// Helper Functions
+func createRuntimeApp(n, ns string, spec runtimeappv1beta1.RuntimeApplicationSpec) *runtimeappv1beta1.RuntimeApplication {
+	app := &runtimeappv1beta1.RuntimeApplication{
+		ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: ns},
+		Spec:       spec,
+	}
+	return app
+}
+
+func createFakeDiscoveryClient() discovery.DiscoveryInterface {
+	fakeDiscoveryClient := &fakediscovery.FakeDiscovery{Fake: &coretesting.Fake{}}
+	fakeDiscoveryClient.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: routev1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "routes", Namespaced: true, Kind: "Route"},
+			},
+		},
+		{
+			GroupVersion: servingv1alpha1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "services", Namespaced: true, Kind: "Service", SingularName: "service"},
+			},
+		},
+		{
+			GroupVersion: certmngrv1alpha2.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "certificates", Namespaced: true, Kind: "Certificate", SingularName: "certificate"},
+			},
+		},
+		{
+			GroupVersion: prometheusv1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "servicemonitors", Namespaced: true, Kind: "ServiceMonitor", SingularName: "servicemonitor"},
+			},
+		},
+	}
+
+	return fakeDiscoveryClient
+}
+
+func createReconcileRequest(n, ns string) reconcile.Request {
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: n, Namespace: ns},
+	}
+	return req
+}
+
+func createConfigMap(n, ns string, data map[string]string) *corev1.ConfigMap {
+	app := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: ns},
+		Data:       data,
+	}
+	return app
+}
+
+func verifyReconcile(res reconcile.Result, err error, t *testing.T) {
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	if res != (reconcile.Result{}) {
+		t.Errorf("reconcile did not return an empty result (%v)", res)
+	}
+}
+
+func verifyTests(n string, tests []Test, t *testing.T) {
+	for _, tt := range tests {
+		if tt.actual != tt.expected {
+			t.Errorf("%s %s test expected: (%v) actual: (%v)", n, tt.test, tt.expected, tt.actual)
+		}
+	}
+}
+
+func updateRuntimeApp(r *ReconcileRuntimeApplication, runtimeapp *runtimeappv1beta1.RuntimeApplication, t *testing.T) {
+	if err := r.GetClient().Update(context.TODO(), runtimeapp); err != nil {
+		t.Fatalf("Update runtimeapp: (%v)", err)
+	}
+}

--- a/pkg/utils/reconciler_test.go
+++ b/pkg/utils/reconciler_test.go
@@ -1,0 +1,228 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/application-runtimes/operator/pkg/common"
+
+	runtimeappv1beta1 "github.com/application-runtimes/operator/pkg/apis/runtimeapp/v1beta1"
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	coretesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var (
+	defaultMeta = metav1.ObjectMeta{
+		Name:      "app",
+		Namespace: "runtimeapp",
+	}
+	spec = runtimeappv1beta1.RuntimeApplicationSpec{}
+)
+
+func TestGetDiscoveryClient(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	runtimeapp := createRuntimeApp(name, namespace, spec)
+	objs, s := []runtime.Object{runtimeapp}, scheme.Scheme
+	s.AddKnownTypes(runtimeappv1beta1.SchemeGroupVersion, runtimeapp)
+	cl := fakeclient.NewFakeClient(objs...)
+
+	r := NewReconcilerBase(cl, s, &rest.Config{}, record.NewFakeRecorder(10))
+
+	newDC, err := r.GetDiscoveryClient()
+
+	if newDC == nil {
+		t.Fatalf("GetDiscoverClient did not create a new discovery client. newDC: (%v) err: (%v)", newDC, err)
+	}
+}
+
+func TestCreateOrUpdate(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	serviceAccount := &corev1.ServiceAccount{ObjectMeta: defaultMeta}
+
+	runtimeapp := createRuntimeApp(name, namespace, spec)
+	objs, s := []runtime.Object{runtimeapp}, scheme.Scheme
+	s.AddKnownTypes(runtimeappv1beta1.SchemeGroupVersion, runtimeapp)
+	cl := fakeclient.NewFakeClient(objs...)
+
+	r := NewReconcilerBase(cl, s, &rest.Config{}, record.NewFakeRecorder(10))
+
+	err := r.CreateOrUpdate(serviceAccount, runtimeapp, func() error {
+		CustomizeServiceAccount(serviceAccount, runtimeapp)
+		return nil
+	})
+
+	testCOU := []Test{{"CreateOrUpdate error is nil", nil, err}}
+	verifyTests(testCOU, t)
+}
+
+func TestDeleteResources(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	runtimeapp := createRuntimeApp(name, namespace, spec)
+	objs, s := []runtime.Object{runtimeapp}, scheme.Scheme
+	s.AddKnownTypes(runtimeappv1beta1.SchemeGroupVersion, runtimeapp)
+	cl := fakeclient.NewFakeClient(objs...)
+	r := NewReconcilerBase(cl, s, &rest.Config{}, record.NewFakeRecorder(10))
+
+	r.SetDiscoveryClient(createFakeDiscoveryClient())
+	nsn := types.NamespacedName{Name: "app", Namespace: "runtimeapp"}
+
+	sa := &corev1.ServiceAccount{ObjectMeta: defaultMeta}
+	ss := &appsv1.StatefulSet{ObjectMeta: defaultMeta}
+	roList := []runtime.Object{sa, ss}
+
+	if err := r.GetClient().Create(context.TODO(), sa); err != nil {
+		t.Fatalf("Create ServiceAccount: (%v)", err)
+	}
+
+	if err := r.GetClient().Get(context.TODO(), nsn, sa); err != nil {
+		t.Fatalf("Get ServiceAccount (%v)", err)
+	}
+
+	if err := r.GetClient().Create(context.TODO(), ss); err != nil {
+		t.Fatalf("Create StatefulSet: (%v)", err)
+	}
+
+	if err := r.GetClient().Get(context.TODO(), nsn, ss); err != nil {
+		t.Fatalf("Get StatefulSet (%v)", err)
+	}
+
+	// Delete Resources
+	r.DeleteResources(roList)
+
+	if err := r.GetClient().Get(context.TODO(), nsn, sa); err == nil {
+		t.Fatalf("ServiceAccount was not deleted")
+	}
+
+	if err := r.GetClient().Get(context.TODO(), nsn, ss); err == nil {
+		t.Fatalf("StatefulSet was not deleted")
+	}
+}
+
+func TestGetOpConfigMap(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data: map[string]string{
+			stack: `{"expose":true, "service":{"port": 3000,"type": "ClusterIP"}}`,
+		},
+	}
+
+	runtimeapp := createRuntimeApp(name, namespace, spec)
+	objs, s := []runtime.Object{runtimeapp}, scheme.Scheme
+	s.AddKnownTypes(runtimeappv1beta1.SchemeGroupVersion, runtimeapp)
+	cl := fakeclient.NewFakeClient(objs...)
+
+	r := NewReconcilerBase(cl, s, &rest.Config{}, record.NewFakeRecorder(10))
+
+	if err := r.GetClient().Create(context.TODO(), configMap); err != nil {
+		t.Fatalf("Create configMap: (%v)", err)
+	}
+
+	cm, err := r.GetOpConfigMap(name, namespace)
+
+	testGAOCM := []Test{
+		{"GetOpConfigMap error is nil", nil, err},
+		{"GetOpConfigMap ConfigMap is correct", true, reflect.DeepEqual(cm.Data, configMap.Data)},
+	}
+	verifyTests(testGAOCM, t)
+}
+
+func TestManageError(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	err := fmt.Errorf("test-error")
+
+	runtimeapp := createRuntimeApp(name, namespace, spec)
+	objs, s := []runtime.Object{runtimeapp}, scheme.Scheme
+	s.AddKnownTypes(runtimeappv1beta1.SchemeGroupVersion, runtimeapp)
+	cl := fakeclient.NewFakeClient(objs...)
+
+	r := NewReconcilerBase(cl, s, &rest.Config{}, record.NewFakeRecorder(10))
+
+	rec, err := r.ManageError(err, common.StatusConditionTypeReconciled, runtimeapp)
+
+	testME := []Test{
+		{"ManageError Requeue", true, rec.Requeue},
+		{"ManageError New Condition Status", corev1.ConditionFalse, runtimeapp.Status.Conditions[0].Status},
+	}
+	verifyTests(testME, t)
+}
+
+func TestManageSuccess(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	runtimeapp := createRuntimeApp(name, namespace, spec)
+	objs, s := []runtime.Object{runtimeapp}, scheme.Scheme
+	s.AddKnownTypes(runtimeappv1beta1.SchemeGroupVersion, runtimeapp)
+	cl := fakeclient.NewFakeClient(objs...)
+	r := NewReconcilerBase(cl, s, &rest.Config{}, record.NewFakeRecorder(10))
+
+	r.ManageSuccess(common.StatusConditionTypeReconciled, runtimeapp)
+
+	testMS := []Test{
+		{"ManageSuccess New Condition Status", corev1.ConditionTrue, runtimeapp.Status.Conditions[0].Status},
+	}
+	verifyTests(testMS, t)
+}
+
+func TestIsGroupVersionSupported(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	runtimeapp := createRuntimeApp(name, namespace, spec)
+	objs, s := []runtime.Object{runtimeapp}, scheme.Scheme
+	s.AddKnownTypes(runtimeappv1beta1.SchemeGroupVersion, runtimeapp)
+	cl := fakeclient.NewFakeClient(objs...)
+
+	r := NewReconcilerBase(cl, s, &rest.Config{}, record.NewFakeRecorder(10))
+	fakeDiscoveryClient := &fakediscovery.FakeDiscovery{
+		Fake: &coretesting.Fake{Resources: []*metav1.APIResourceList{{GroupVersion: "v1"}}},
+	}
+	r.SetDiscoveryClient(fakeDiscoveryClient)
+
+	_, err := r.IsGroupVersionSupported("v1")
+	if err != nil {
+		t.Fatalf("Group version should be supported: (%v)", err)
+	}
+
+	_, err = r.IsGroupVersionSupported("v2")
+	if err == nil {
+		t.Fatalf("Group version should not be supported")
+	}
+}
+
+func createFakeDiscoveryClient() discovery.DiscoveryInterface {
+	fakeDiscoveryClient := &fakediscovery.FakeDiscovery{Fake: &coretesting.Fake{}}
+	fakeDiscoveryClient.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: routev1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "routes", Namespaced: true, Kind: "Route"},
+			},
+		},
+		{
+			GroupVersion: servingv1alpha1.SchemeGroupVersion.String(),
+			APIResources: []metav1.APIResource{
+				{Name: "services", Namespaced: true, Kind: "Service", SingularName: "service"},
+			},
+		},
+	}
+
+	return fakeDiscoveryClient
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,536 @@
+package utils
+
+import (
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+
+	runtimeappv1beta1 "github.com/application-runtimes/operator/pkg/apis/runtimeapp/v1beta1"
+	prometheusv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var (
+	name               = "my-app"
+	namespace          = "runtime"
+	stack              = "java-microprofile"
+	appImage           = "my-image"
+	replicas     int32 = 2
+	expose             = true
+	createKNS          = true
+	targetCPUPer int32 = 30
+	autoscaling        = &runtimeappv1beta1.RuntimeApplicationAutoScaling{
+		TargetCPUUtilizationPercentage: &targetCPUPer,
+		MinReplicas:                    &replicas,
+		MaxReplicas:                    3,
+	}
+	envFrom            = []corev1.EnvFromSource{{Prefix: namespace}}
+	env                = []corev1.EnvVar{{Name: namespace}}
+	pullPolicy         = corev1.PullAlways
+	pullSecret         = "mysecret"
+	serviceAccountName = "service-account"
+	serviceType        = corev1.ServiceTypeClusterIP
+	service            = &runtimeappv1beta1.RuntimeApplicationService{Type: &serviceType, Port: 8443}
+	volumeCT           = &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: namespace},
+		TypeMeta:   metav1.TypeMeta{Kind: "StatefulSet"}}
+	storage        = runtimeappv1beta1.RuntimeApplicationStorage{Size: "10Mi", MountPath: "/mnt/data", VolumeClaimTemplate: volumeCT}
+	arch           = []string{"ppc64le"}
+	readinessProbe = &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet:   &corev1.HTTPGetAction{},
+			TCPSocket: &corev1.TCPSocketAction{},
+		},
+	}
+	livenessProbe = &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet:   &corev1.HTTPGetAction{},
+			TCPSocket: &corev1.TCPSocketAction{},
+		},
+	}
+	volume      = corev1.Volume{Name: "runtime-volume"}
+	volumeMount = corev1.VolumeMount{Name: volumeCT.Name, MountPath: storage.MountPath}
+	resLimits   = map[corev1.ResourceName]resource.Quantity{
+		corev1.ResourceCPU: {},
+	}
+	resourceContraints = &corev1.ResourceRequirements{Limits: resLimits}
+)
+
+type Test struct {
+	test     string
+	expected interface{}
+	actual   interface{}
+}
+
+func TestCustomizeRoute(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	spec := runtimeappv1beta1.RuntimeApplicationSpec{Service: service}
+	route, runtime := &routev1.Route{}, createRuntimeApp(name, namespace, spec)
+
+	CustomizeRoute(route, runtime, "", "", "", "")
+
+	//TestGetLabels
+	testCR := []Test{
+		{"Route labels", name, route.Labels["app.kubernetes.io/instance"]},
+		{"Route target kind", "Service", route.Spec.To.Kind},
+		{"Route target name", name, route.Spec.To.Name},
+		{"Route target weight", int32(100), *route.Spec.To.Weight},
+		{"Route service target port", intstr.FromString(strconv.Itoa(int(runtime.Spec.Service.Port)) + "-tcp"), route.Spec.Port.TargetPort},
+	}
+
+	verifyTests(testCR, t)
+}
+
+func TestCustomizeService(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	spec := runtimeappv1beta1.RuntimeApplicationSpec{Service: service}
+	svc, runtime := &corev1.Service{}, createRuntimeApp(name, namespace, spec)
+
+	CustomizeService(svc, runtime)
+	testCS := []Test{
+		{"Service number of exposed ports", 1, len(svc.Spec.Ports)},
+		{"Sercice first exposed port", runtime.Spec.Service.Port, svc.Spec.Ports[0].Port},
+		{"Service first exposed target port", intstr.FromInt(int(runtime.Spec.Service.Port)), svc.Spec.Ports[0].TargetPort},
+		{"Service type", *runtime.Spec.Service.Type, svc.Spec.Type},
+		{"Service selector", name, svc.Spec.Selector["app.kubernetes.io/instance"]},
+	}
+	verifyTests(testCS, t)
+}
+
+func TestCustomizePodSpec(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	spec := runtimeappv1beta1.RuntimeApplicationSpec{
+		ApplicationImage:    appImage,
+		Service:             service,
+		ResourceConstraints: resourceContraints,
+		ReadinessProbe:      readinessProbe,
+		LivenessProbe:       livenessProbe,
+		VolumeMounts:        []corev1.VolumeMount{volumeMount},
+		PullPolicy:          &pullPolicy,
+		Env:                 env,
+		EnvFrom:             envFrom,
+		Volumes:             []corev1.Volume{volume},
+	}
+	pts, runtime := &corev1.PodTemplateSpec{}, createRuntimeApp(name, namespace, spec)
+	// else cond
+	CustomizePodSpec(pts, runtime)
+	noCont := len(pts.Spec.Containers)
+	noPorts := len(pts.Spec.Containers[0].Ports)
+	ptsSAN := pts.Spec.ServiceAccountName
+	// if cond
+	spec = runtimeappv1beta1.RuntimeApplicationSpec{
+		ApplicationImage:    appImage,
+		Service:             service,
+		ResourceConstraints: resourceContraints,
+		ReadinessProbe:      readinessProbe,
+		LivenessProbe:       livenessProbe,
+		VolumeMounts:        []corev1.VolumeMount{volumeMount},
+		PullPolicy:          &pullPolicy,
+		Env:                 env,
+		EnvFrom:             envFrom,
+		Volumes:             []corev1.Volume{volume},
+		Architecture:        arch,
+		ServiceAccountName:  &serviceAccountName,
+	}
+	runtime = createRuntimeApp(name, namespace, spec)
+	CustomizePodSpec(pts, runtime)
+	ptsCSAN := pts.Spec.ServiceAccountName
+
+	// affinity tests
+	affArchs := pts.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Values[0]
+	weight := pts.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].Weight
+	prefAffArchs := pts.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].Preference.MatchExpressions[0].Values[0]
+
+	testCPS := []Test{
+		{"No containers", 1, noCont},
+		{"No port", 1, noPorts},
+		{"No ServiceAccountName", name, ptsSAN},
+		{"ServiceAccountName available", serviceAccountName, ptsCSAN},
+	}
+	verifyTests(testCPS, t)
+
+	testCA := []Test{
+		{"Archs", arch[0], affArchs},
+		{"Weight", int32(1), int32(weight)},
+		{"Archs", arch[0], prefAffArchs},
+	}
+	verifyTests(testCA, t)
+}
+
+func TestCustomizePersistence(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	spec := runtimeappv1beta1.RuntimeApplicationSpec{Storage: &storage}
+	statefulSet, runtime := &appsv1.StatefulSet{}, createRuntimeApp(name, namespace, spec)
+	statefulSet.Spec.Template.Spec.Containers = []corev1.Container{{}}
+	statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{}
+	// if vct == 0, runtimeVCT != nil, not found
+	CustomizePersistence(statefulSet, runtime)
+	ssK := statefulSet.Spec.VolumeClaimTemplates[0].TypeMeta.Kind
+	ssMountPath := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath
+
+	//reset
+	storageNilVCT := runtimeappv1beta1.RuntimeApplicationStorage{Size: "10Mi", MountPath: "/mnt/data", VolumeClaimTemplate: nil}
+	spec = runtimeappv1beta1.RuntimeApplicationSpec{Storage: &storageNilVCT}
+	statefulSet, runtime = &appsv1.StatefulSet{}, createRuntimeApp(name, namespace, spec)
+
+	statefulSet.Spec.Template.Spec.Containers = []corev1.Container{{}}
+	statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts = append(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMount)
+	//runtimeVCT == nil, found
+	CustomizePersistence(statefulSet, runtime)
+	ssVolumeMountName := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name
+	size := statefulSet.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage]
+	testCP := []Test{
+		{"Persistence kind with VCT", volumeCT.TypeMeta.Kind, ssK},
+		{"PVC size", storage.Size, size.String()},
+		{"Mount path", storage.MountPath, ssMountPath},
+		{"Volume Mount Name", volumeCT.Name, ssVolumeMountName},
+	}
+	verifyTests(testCP, t)
+}
+
+func TestCustomizeServiceAccount(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	spec := runtimeappv1beta1.RuntimeApplicationSpec{PullSecret: &pullSecret}
+	sa, runtime := &corev1.ServiceAccount{}, createRuntimeApp(name, namespace, spec)
+	CustomizeServiceAccount(sa, runtime)
+	emptySAIPS := sa.ImagePullSecrets[0].Name
+
+	newSecret := "my-new-secret"
+	spec = runtimeappv1beta1.RuntimeApplicationSpec{PullSecret: &newSecret}
+	runtime = createRuntimeApp(name, namespace, spec)
+	CustomizeServiceAccount(sa, runtime)
+
+	testCSA := []Test{
+		{"ServiceAccount image pull secrets is empty", pullSecret, emptySAIPS},
+		{"ServiceAccount image pull secrets", newSecret, sa.ImagePullSecrets[0].Name},
+	}
+	verifyTests(testCSA, t)
+}
+
+func TestCustomizeKnativeService(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	spec := runtimeappv1beta1.RuntimeApplicationSpec{
+		ApplicationImage: appImage,
+		Service:          service,
+		LivenessProbe:    livenessProbe,
+		ReadinessProbe:   readinessProbe,
+		PullPolicy:       &pullPolicy,
+		Env:              env,
+		EnvFrom:          envFrom,
+		Volumes:          []corev1.Volume{volume},
+	}
+	ksvc, runtime := &servingv1alpha1.Service{}, createRuntimeApp(name, namespace, spec)
+
+	CustomizeKnativeService(ksvc, runtime)
+	ksvcNumPorts := len(ksvc.Spec.Template.Spec.Containers[0].Ports)
+	ksvcSAN := ksvc.Spec.Template.Spec.ServiceAccountName
+
+	ksvcLPPort := ksvc.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Port
+	ksvcLPTCP := ksvc.Spec.Template.Spec.Containers[0].LivenessProbe.TCPSocket.Port
+	ksvcRPPort := ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Port
+	ksvcRPTCP := ksvc.Spec.Template.Spec.Containers[0].ReadinessProbe.TCPSocket.Port
+	ksvcLabelNoExpose := ksvc.Labels["serving.knative.dev/visibility"]
+
+	spec = runtimeappv1beta1.RuntimeApplicationSpec{
+		ApplicationImage:   appImage,
+		Service:            service,
+		PullPolicy:         &pullPolicy,
+		Env:                env,
+		EnvFrom:            envFrom,
+		Volumes:            []corev1.Volume{volume},
+		ServiceAccountName: &serviceAccountName,
+		LivenessProbe:      livenessProbe,
+		ReadinessProbe:     readinessProbe,
+		Expose:             &expose,
+	}
+	runtime = createRuntimeApp(name, namespace, spec)
+	CustomizeKnativeService(ksvc, runtime)
+	ksvcLabelTrueExpose := ksvc.Labels["serving.knative.dev/visibility"]
+
+	fls := false
+	runtime.Spec.Expose = &fls
+	CustomizeKnativeService(ksvc, runtime)
+	ksvcLabelFalseExpose := ksvc.Labels["serving.knative.dev/visibility"]
+
+	testCKS := []Test{
+		{"ksvc container ports", 1, ksvcNumPorts},
+		{"ksvc ServiceAccountName is nil", name, ksvcSAN},
+		{"ksvc ServiceAccountName not nil", *runtime.Spec.ServiceAccountName, ksvc.Spec.Template.Spec.ServiceAccountName},
+		{"liveness probe port", intstr.IntOrString{}, ksvcLPPort},
+		{"liveness probe TCP socket port", intstr.IntOrString{}, ksvcLPTCP},
+		{"Readiness probe port", intstr.IntOrString{}, ksvcRPPort},
+		{"Readiness probe TCP socket port", intstr.IntOrString{}, ksvcRPTCP},
+		{"expose not set", "cluster-local", ksvcLabelNoExpose},
+		{"expose set to true", "", ksvcLabelTrueExpose},
+		{"expose set to false", "cluster-local", ksvcLabelFalseExpose},
+	}
+	verifyTests(testCKS, t)
+}
+
+func TestCustomizeHPA(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	spec := runtimeappv1beta1.RuntimeApplicationSpec{Autoscaling: autoscaling}
+	hpa, runtime := &autoscalingv1.HorizontalPodAutoscaler{}, createRuntimeApp(name, namespace, spec)
+	CustomizeHPA(hpa, runtime)
+	nilSTRKind := hpa.Spec.ScaleTargetRef.Kind
+
+	spec = runtimeappv1beta1.RuntimeApplicationSpec{Autoscaling: autoscaling, Storage: &storage}
+	runtime = createRuntimeApp(name, namespace, spec)
+	CustomizeHPA(hpa, runtime)
+	STRKind := hpa.Spec.ScaleTargetRef.Kind
+
+	testCHPA := []Test{
+		{"Max replicas", autoscaling.MaxReplicas, hpa.Spec.MaxReplicas},
+		{"Min replicas", *autoscaling.MinReplicas, *hpa.Spec.MinReplicas},
+		{"Target CPU utilization", *autoscaling.TargetCPUUtilizationPercentage, *hpa.Spec.TargetCPUUtilizationPercentage},
+		{"", name, hpa.Spec.ScaleTargetRef.Name},
+		{"", "apps/v1", hpa.Spec.ScaleTargetRef.APIVersion},
+		{"Storage not enabled", "Deployment", nilSTRKind},
+		{"Storage enabled", "StatefulSet", STRKind},
+	}
+	verifyTests(testCHPA, t)
+}
+
+func TestCustomizeServiceMonitor(t *testing.T) {
+
+	logf.SetLogger(logf.ZapLogger(true))
+	spec := runtimeappv1beta1.RuntimeApplicationSpec{Service: service}
+
+	params := map[string][]string{
+		"params": []string{"param1", "param2"},
+	}
+
+	// Endpoint for runtime
+	endpointApp := &prometheusv1.Endpoint{
+		Port:            "web",
+		Scheme:          "myScheme",
+		Interval:        "myInterval",
+		Path:            "myPath",
+		TLSConfig:       &prometheusv1.TLSConfig{},
+		BasicAuth:       &prometheusv1.BasicAuth{},
+		Params:          params,
+		ScrapeTimeout:   "myScrapeTimeout",
+		BearerTokenFile: "myBearerTokenFile",
+	}
+	endpointsApp := make([]prometheusv1.Endpoint, 1)
+	endpointsApp[0] = *endpointApp
+
+	// Endpoint for sm
+	endpointsSM := make([]prometheusv1.Endpoint, 0)
+
+	labelMap := map[string]string{"app": "my-app"}
+	selector := &metav1.LabelSelector{MatchLabels: labelMap}
+	smspec := &prometheusv1.ServiceMonitorSpec{Endpoints: endpointsSM, Selector: *selector}
+
+	sm, runtime := &prometheusv1.ServiceMonitor{Spec: *smspec}, createRuntimeApp(name, namespace, spec)
+	runtime.Spec.Monitoring = &runtimeappv1beta1.RuntimeApplicationMonitoring{Labels: labelMap, Endpoints: endpointsApp}
+
+	CustomizeServiceMonitor(sm, runtime)
+
+	labelMatches := map[string]string{
+		"app.runtime.app/monitor":    "true",
+		"app.kubernetes.io/instance": name,
+	}
+
+	allSMLabels := runtime.GetLabels()
+	for key, value := range runtime.Spec.Monitoring.Labels {
+		allSMLabels[key] = value
+	}
+
+	// Expected values
+	appScheme := runtime.Spec.Monitoring.Endpoints[0].Scheme
+	appInterval := runtime.Spec.Monitoring.Endpoints[0].Interval
+	appPath := runtime.Spec.Monitoring.Endpoints[0].Path
+	appTLSConfig := runtime.Spec.Monitoring.Endpoints[0].TLSConfig
+	appBasicAuth := runtime.Spec.Monitoring.Endpoints[0].BasicAuth
+	appParams := runtime.Spec.Monitoring.Endpoints[0].Params
+	appScrapeTimeout := runtime.Spec.Monitoring.Endpoints[0].ScrapeTimeout
+	appBearerTokenFile := runtime.Spec.Monitoring.Endpoints[0].BearerTokenFile
+
+	testSM := []Test{
+		{"Service Monitor label for app.kubernetes.io/instance", name, sm.Labels["app.kubernetes.io/instance"]},
+		{"Service Monitor selector match labels", labelMatches, sm.Spec.Selector.MatchLabels},
+		{"Service Monitor endpoints port", strconv.Itoa(int(runtime.Spec.Service.Port)) + "-tcp", sm.Spec.Endpoints[0].Port},
+		{"Service Monitor all labels", allSMLabels, sm.Labels},
+		{"Service Monitor endpoints scheme", appScheme, sm.Spec.Endpoints[0].Scheme},
+		{"Service Monitor endpoints interval", appInterval, sm.Spec.Endpoints[0].Interval},
+		{"Service Monitor endpoints path", appPath, sm.Spec.Endpoints[0].Path},
+		{"Service Monitor endpoints TLSConfig", appTLSConfig, sm.Spec.Endpoints[0].TLSConfig},
+		{"Service Monitor endpoints basicAuth", appBasicAuth, sm.Spec.Endpoints[0].BasicAuth},
+		{"Service Monitor endpoints params", appParams, sm.Spec.Endpoints[0].Params},
+		{"Service Monitor endpoints scrapeTimeout", appScrapeTimeout, sm.Spec.Endpoints[0].ScrapeTimeout},
+		{"Service Monitor endpoints bearerTokenFile", appBearerTokenFile, sm.Spec.Endpoints[0].BearerTokenFile},
+	}
+
+	verifyTests(testSM, t)
+}
+
+func TestGetCondition(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	status := &runtimeappv1beta1.RuntimeApplicationStatus{
+		Conditions: []runtimeappv1beta1.StatusCondition{
+			{
+				Status: corev1.ConditionTrue,
+				Type:   runtimeappv1beta1.StatusConditionTypeReconciled,
+			},
+		},
+	}
+	conditionType := runtimeappv1beta1.StatusConditionTypeReconciled
+	cond := GetCondition(conditionType, status)
+	testGC := []Test{{"Set status condition", status.Conditions[0].Status, cond.Status}}
+	verifyTests(testGC, t)
+}
+
+func TestSetCondition(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	status := &runtimeappv1beta1.RuntimeApplicationStatus{
+		Conditions: []runtimeappv1beta1.StatusCondition{
+			{Type: runtimeappv1beta1.StatusConditionTypeReconciled},
+		},
+	}
+	condition := runtimeappv1beta1.StatusCondition{
+		Status: corev1.ConditionTrue,
+		Type:   runtimeappv1beta1.StatusConditionTypeReconciled,
+	}
+	SetCondition(condition, status)
+	testSC := []Test{{"Set status condition", condition.Status, status.Conditions[0].Status}}
+	verifyTests(testSC, t)
+}
+
+func TestGetWatchNamespaces(t *testing.T) {
+	// Set the logger to development mode for verbose logs
+	logf.SetLogger(logf.ZapLogger(true))
+
+	os.Setenv("WATCH_NAMESPACE", "")
+	namespaces, err := GetWatchNamespaces()
+	configMapConstTests := []Test{
+		{"namespaces", []string{""}, namespaces},
+		{"error", nil, err},
+	}
+	verifyTests(configMapConstTests, t)
+
+	os.Setenv("WATCH_NAMESPACE", "ns1")
+	namespaces, err = GetWatchNamespaces()
+	configMapConstTests = []Test{
+		{"namespaces", []string{"ns1"}, namespaces},
+		{"error", nil, err},
+	}
+	verifyTests(configMapConstTests, t)
+
+	os.Setenv("WATCH_NAMESPACE", "ns1,ns2,ns3")
+	namespaces, err = GetWatchNamespaces()
+	configMapConstTests = []Test{
+		{"namespaces", []string{"ns1", "ns2", "ns3"}, namespaces},
+		{"error", nil, err},
+	}
+	verifyTests(configMapConstTests, t)
+
+	os.Setenv("WATCH_NAMESPACE", " ns1   ,  ns2,  ns3  ")
+	namespaces, err = GetWatchNamespaces()
+	configMapConstTests = []Test{
+		{"namespaces", []string{"ns1", "ns2", "ns3"}, namespaces},
+		{"error", nil, err},
+	}
+	verifyTests(configMapConstTests, t)
+}
+
+func TestUpdateAppDefinition(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+
+	spec := runtimeappv1beta1.RuntimeApplicationSpec{Service: service, Version: "v1alpha"}
+	app := createRuntimeApp(name, namespace, spec)
+
+	// Toggle app definition off [disabled]
+	enabled := false
+	app.Spec.CreateAppDefinition = &enabled
+	labels, annotations := createAppDefinitionTags(app)
+	UpdateAppDefinition(labels, annotations, app)
+
+	appDefinitionTests := []Test{
+		{"Label unset", 0, len(labels)},
+		{"Annotation unset", 0, len(annotations)},
+	}
+
+	verifyTests(appDefinitionTests, t)
+
+	// Toggle back on [active]
+	enabled = true
+	completeLabels, completeAnnotations := createAppDefinitionTags(app)
+	UpdateAppDefinition(labels, annotations, app)
+
+	appDefinitionTests = []Test{
+		{"Label set", labels["kappnav.app.auto-create"], completeLabels["kappnav.app.auto-create"]},
+		{"Annotation name set", annotations["kappnav.app.auto-create.name"], completeAnnotations["kappnav.app.auto-create.name"]},
+		{"Annotation kinds set", annotations["kappnav.app.auto-create.kinds"], completeAnnotations["kappnav.app.auto-create.kinds"]},
+		{"Annotation label set", annotations["kappnav.app.auto-create.label"], completeAnnotations["kappnav.app.auto-create.label"]},
+		{"Annotation labels-values", annotations["kappnav.app.auto-create.labels-values"], completeAnnotations["kappnav.app.auto-create.labels-values"]},
+		{"Annotation version set", annotations["kappnav.app.auto-create.version"], completeAnnotations["kappnav.app.auto-create.version"]},
+	}
+	verifyTests(appDefinitionTests, t)
+
+	// Verify labels are still set when CreateApp is undefined [default]
+	app.Spec.CreateAppDefinition = nil
+	UpdateAppDefinition(labels, annotations, app)
+
+	appDefinitionTests = []Test{
+		{"Label set", labels["kappnav.app.auto-create"], completeLabels["kappnav.app.auto-create"]},
+		{"Annotation name set", annotations["kappnav.app.auto-create.name"], completeAnnotations["kappnav.app.auto-create.name"]},
+		{"Annotation kinds set", annotations["kappnav.app.auto-create.kinds"], completeAnnotations["kappnav.app.auto-create.kinds"]},
+		{"Annotation label set", annotations["kappnav.app.auto-create.label"], completeAnnotations["kappnav.app.auto-create.label"]},
+		{"Annotation labels-values", annotations["kappnav.app.auto-create.labels-values"], completeAnnotations["kappnav.app.auto-create.labels-values"]},
+		{"Annotation version set", annotations["kappnav.app.auto-create.version"], completeAnnotations["kappnav.app.auto-create.version"]},
+	}
+	verifyTests(appDefinitionTests, t)
+
+}
+
+// Helper Functions
+// Unconditionally set the proper tags for an enabled runtime application
+func createAppDefinitionTags(app *runtimeappv1beta1.RuntimeApplication) (map[string]string, map[string]string) {
+	// The purpose of this function demands all fields configured
+	if app.Spec.Version == "" {
+		app.Spec.Version = "v1alpha"
+	}
+	// set fields
+	label := map[string]string{
+		"kappnav.app.auto-create": "true",
+	}
+	annotations := map[string]string{
+		"kappnav.app.auto-create.name":          app.Name,
+		"kappnav.app.auto-create.kinds":         "Deployment, StatefulSet, Service, Route, Ingress, ConfigMap",
+		"kappnav.app.auto-create.label":         "app.kubernetes.io/instance",
+		"kappnav.app.auto-create.labels-values": app.Name,
+		"kappnav.app.auto-create.version":       app.Spec.Version,
+	}
+	return label, annotations
+}
+func createRuntimeApp(n, ns string, spec runtimeappv1beta1.RuntimeApplicationSpec) *runtimeappv1beta1.RuntimeApplication {
+	app := &runtimeappv1beta1.RuntimeApplication{
+		ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: ns},
+		Spec:       spec,
+	}
+	return app
+}
+
+func verifyTests(tests []Test, t *testing.T) {
+	for _, tt := range tests {
+		if !reflect.DeepEqual(tt.actual, tt.expected) {
+			t.Errorf("%s test expected: (%v) actual: (%v)", tt.test, tt.expected, tt.actual)
+		}
+	}
+}

--- a/vendor/k8s.io/client-go/discovery/fake/discovery.go
+++ b/vendor/k8s.io/client-go/discovery/fake/discovery.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"fmt"
+
+	"github.com/googleapis/gnostic/OpenAPIv2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	kubeversion "k8s.io/client-go/pkg/version"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/testing"
+)
+
+// FakeDiscovery implements discovery.DiscoveryInterface and sometimes calls testing.Fake.Invoke with an action,
+// but doesn't respect the return value if any. There is a way to fake static values like ServerVersion by using the Faked... fields on the struct.
+type FakeDiscovery struct {
+	*testing.Fake
+	FakedServerVersion *version.Info
+}
+
+// ServerResourcesForGroupVersion returns the supported resources for a group
+// and version.
+func (c *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	action := testing.ActionImpl{
+		Verb:     "get",
+		Resource: schema.GroupVersionResource{Resource: "resource"},
+	}
+	c.Invokes(action, nil)
+	for _, resourceList := range c.Resources {
+		if resourceList.GroupVersion == groupVersion {
+			return resourceList, nil
+		}
+	}
+	return nil, fmt.Errorf("GroupVersion %q not found", groupVersion)
+}
+
+// ServerResources returns the supported resources for all groups and versions.
+// Deprecated: use ServerGroupsAndResources instead.
+func (c *FakeDiscovery) ServerResources() ([]*metav1.APIResourceList, error) {
+	_, rs, err := c.ServerGroupsAndResources()
+	return rs, err
+}
+
+// ServerGroupsAndResources returns the supported groups and resources for all groups and versions.
+func (c *FakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	sgs, err := c.ServerGroups()
+	if err != nil {
+		return nil, nil, err
+	}
+	resultGroups := []*metav1.APIGroup{}
+	for i := range sgs.Groups {
+		resultGroups = append(resultGroups, &sgs.Groups[i])
+	}
+
+	action := testing.ActionImpl{
+		Verb:     "get",
+		Resource: schema.GroupVersionResource{Resource: "resource"},
+	}
+	c.Invokes(action, nil)
+	return resultGroups, c.Resources, nil
+}
+
+// ServerPreferredResources returns the supported resources with the version
+// preferred by the server.
+func (c *FakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+// ServerPreferredNamespacedResources returns the supported namespaced resources
+// with the version preferred by the server.
+func (c *FakeDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+// ServerGroups returns the supported groups, with information like supported
+// versions and the preferred version.
+func (c *FakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	action := testing.ActionImpl{
+		Verb:     "get",
+		Resource: schema.GroupVersionResource{Resource: "group"},
+	}
+	c.Invokes(action, nil)
+
+	groups := map[string]*metav1.APIGroup{}
+
+	for _, res := range c.Resources {
+		gv, err := schema.ParseGroupVersion(res.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+		group := groups[gv.Group]
+		if group == nil {
+			group = &metav1.APIGroup{
+				Name: gv.Group,
+				PreferredVersion: metav1.GroupVersionForDiscovery{
+					GroupVersion: res.GroupVersion,
+					Version:      gv.Version,
+				},
+			}
+			groups[gv.Group] = group
+		}
+
+		group.Versions = append(group.Versions, metav1.GroupVersionForDiscovery{
+			GroupVersion: res.GroupVersion,
+			Version:      gv.Version,
+		})
+	}
+
+	list := &metav1.APIGroupList{}
+	for _, apiGroup := range groups {
+		list.Groups = append(list.Groups, *apiGroup)
+	}
+
+	return list, nil
+
+}
+
+// ServerVersion retrieves and parses the server's version.
+func (c *FakeDiscovery) ServerVersion() (*version.Info, error) {
+	action := testing.ActionImpl{}
+	action.Verb = "get"
+	action.Resource = schema.GroupVersionResource{Resource: "version"}
+	c.Invokes(action, nil)
+
+	if c.FakedServerVersion != nil {
+		return c.FakedServerVersion, nil
+	}
+
+	versionInfo := kubeversion.Get()
+	return &versionInfo, nil
+}
+
+// OpenAPISchema retrieves and parses the swagger API schema the server supports.
+func (c *FakeDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
+	return &openapi_v2.Document{}, nil
+}
+
+// RESTClient returns a RESTClient that is used to communicate with API server
+// by this client implementation.
+func (c *FakeDiscovery) RESTClient() restclient.Interface {
+	return nil
+}

--- a/vendor/k8s.io/client-go/testing/actions.go
+++ b/vendor/k8s.io/client-go/testing/actions.go
@@ -1,0 +1,671 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func NewRootGetAction(resource schema.GroupVersionResource, name string) GetActionImpl {
+	action := GetActionImpl{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Name = name
+
+	return action
+}
+
+func NewGetAction(resource schema.GroupVersionResource, namespace, name string) GetActionImpl {
+	action := GetActionImpl{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Name = name
+
+	return action
+}
+
+func NewGetSubresourceAction(resource schema.GroupVersionResource, namespace, subresource, name string) GetActionImpl {
+	action := GetActionImpl{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Namespace = namespace
+	action.Name = name
+
+	return action
+}
+
+func NewRootGetSubresourceAction(resource schema.GroupVersionResource, subresource, name string) GetActionImpl {
+	action := GetActionImpl{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Name = name
+
+	return action
+}
+
+func NewRootListAction(resource schema.GroupVersionResource, kind schema.GroupVersionKind, opts interface{}) ListActionImpl {
+	action := ListActionImpl{}
+	action.Verb = "list"
+	action.Resource = resource
+	action.Kind = kind
+	labelSelector, fieldSelector, _ := ExtractFromListOptions(opts)
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+
+	return action
+}
+
+func NewListAction(resource schema.GroupVersionResource, kind schema.GroupVersionKind, namespace string, opts interface{}) ListActionImpl {
+	action := ListActionImpl{}
+	action.Verb = "list"
+	action.Resource = resource
+	action.Kind = kind
+	action.Namespace = namespace
+	labelSelector, fieldSelector, _ := ExtractFromListOptions(opts)
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+
+	return action
+}
+
+func NewRootCreateAction(resource schema.GroupVersionResource, object runtime.Object) CreateActionImpl {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = resource
+	action.Object = object
+
+	return action
+}
+
+func NewCreateAction(resource schema.GroupVersionResource, namespace string, object runtime.Object) CreateActionImpl {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Object = object
+
+	return action
+}
+
+func NewRootCreateSubresourceAction(resource schema.GroupVersionResource, name, subresource string, object runtime.Object) CreateActionImpl {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Name = name
+	action.Object = object
+
+	return action
+}
+
+func NewCreateSubresourceAction(resource schema.GroupVersionResource, name, subresource, namespace string, object runtime.Object) CreateActionImpl {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Subresource = subresource
+	action.Name = name
+	action.Object = object
+
+	return action
+}
+
+func NewRootUpdateAction(resource schema.GroupVersionResource, object runtime.Object) UpdateActionImpl {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Resource = resource
+	action.Object = object
+
+	return action
+}
+
+func NewUpdateAction(resource schema.GroupVersionResource, namespace string, object runtime.Object) UpdateActionImpl {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Object = object
+
+	return action
+}
+
+func NewRootPatchAction(resource schema.GroupVersionResource, name string, pt types.PatchType, patch []byte) PatchActionImpl {
+	action := PatchActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Name = name
+	action.PatchType = pt
+	action.Patch = patch
+
+	return action
+}
+
+func NewPatchAction(resource schema.GroupVersionResource, namespace string, name string, pt types.PatchType, patch []byte) PatchActionImpl {
+	action := PatchActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Name = name
+	action.PatchType = pt
+	action.Patch = patch
+
+	return action
+}
+
+func NewRootPatchSubresourceAction(resource schema.GroupVersionResource, name string, pt types.PatchType, patch []byte, subresources ...string) PatchActionImpl {
+	action := PatchActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Subresource = path.Join(subresources...)
+	action.Name = name
+	action.PatchType = pt
+	action.Patch = patch
+
+	return action
+}
+
+func NewPatchSubresourceAction(resource schema.GroupVersionResource, namespace, name string, pt types.PatchType, patch []byte, subresources ...string) PatchActionImpl {
+	action := PatchActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Subresource = path.Join(subresources...)
+	action.Namespace = namespace
+	action.Name = name
+	action.PatchType = pt
+	action.Patch = patch
+
+	return action
+}
+
+func NewRootUpdateSubresourceAction(resource schema.GroupVersionResource, subresource string, object runtime.Object) UpdateActionImpl {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Object = object
+
+	return action
+}
+func NewUpdateSubresourceAction(resource schema.GroupVersionResource, subresource string, namespace string, object runtime.Object) UpdateActionImpl {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Namespace = namespace
+	action.Object = object
+
+	return action
+}
+
+func NewRootDeleteAction(resource schema.GroupVersionResource, name string) DeleteActionImpl {
+	action := DeleteActionImpl{}
+	action.Verb = "delete"
+	action.Resource = resource
+	action.Name = name
+
+	return action
+}
+
+func NewRootDeleteSubresourceAction(resource schema.GroupVersionResource, subresource string, name string) DeleteActionImpl {
+	action := DeleteActionImpl{}
+	action.Verb = "delete"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Name = name
+
+	return action
+}
+
+func NewDeleteAction(resource schema.GroupVersionResource, namespace, name string) DeleteActionImpl {
+	action := DeleteActionImpl{}
+	action.Verb = "delete"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Name = name
+
+	return action
+}
+
+func NewDeleteSubresourceAction(resource schema.GroupVersionResource, subresource, namespace, name string) DeleteActionImpl {
+	action := DeleteActionImpl{}
+	action.Verb = "delete"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Namespace = namespace
+	action.Name = name
+
+	return action
+}
+
+func NewRootDeleteCollectionAction(resource schema.GroupVersionResource, opts interface{}) DeleteCollectionActionImpl {
+	action := DeleteCollectionActionImpl{}
+	action.Verb = "delete-collection"
+	action.Resource = resource
+	labelSelector, fieldSelector, _ := ExtractFromListOptions(opts)
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+
+	return action
+}
+
+func NewDeleteCollectionAction(resource schema.GroupVersionResource, namespace string, opts interface{}) DeleteCollectionActionImpl {
+	action := DeleteCollectionActionImpl{}
+	action.Verb = "delete-collection"
+	action.Resource = resource
+	action.Namespace = namespace
+	labelSelector, fieldSelector, _ := ExtractFromListOptions(opts)
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+
+	return action
+}
+
+func NewRootWatchAction(resource schema.GroupVersionResource, opts interface{}) WatchActionImpl {
+	action := WatchActionImpl{}
+	action.Verb = "watch"
+	action.Resource = resource
+	labelSelector, fieldSelector, resourceVersion := ExtractFromListOptions(opts)
+	action.WatchRestrictions = WatchRestrictions{labelSelector, fieldSelector, resourceVersion}
+
+	return action
+}
+
+func ExtractFromListOptions(opts interface{}) (labelSelector labels.Selector, fieldSelector fields.Selector, resourceVersion string) {
+	var err error
+	switch t := opts.(type) {
+	case metav1.ListOptions:
+		labelSelector, err = labels.Parse(t.LabelSelector)
+		if err != nil {
+			panic(fmt.Errorf("invalid selector %q: %v", t.LabelSelector, err))
+		}
+		fieldSelector, err = fields.ParseSelector(t.FieldSelector)
+		if err != nil {
+			panic(fmt.Errorf("invalid selector %q: %v", t.FieldSelector, err))
+		}
+		resourceVersion = t.ResourceVersion
+	default:
+		panic(fmt.Errorf("expect a ListOptions %T", opts))
+	}
+	if labelSelector == nil {
+		labelSelector = labels.Everything()
+	}
+	if fieldSelector == nil {
+		fieldSelector = fields.Everything()
+	}
+	return labelSelector, fieldSelector, resourceVersion
+}
+
+func NewWatchAction(resource schema.GroupVersionResource, namespace string, opts interface{}) WatchActionImpl {
+	action := WatchActionImpl{}
+	action.Verb = "watch"
+	action.Resource = resource
+	action.Namespace = namespace
+	labelSelector, fieldSelector, resourceVersion := ExtractFromListOptions(opts)
+	action.WatchRestrictions = WatchRestrictions{labelSelector, fieldSelector, resourceVersion}
+
+	return action
+}
+
+func NewProxyGetAction(resource schema.GroupVersionResource, namespace, scheme, name, port, path string, params map[string]string) ProxyGetActionImpl {
+	action := ProxyGetActionImpl{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Scheme = scheme
+	action.Name = name
+	action.Port = port
+	action.Path = path
+	action.Params = params
+	return action
+}
+
+type ListRestrictions struct {
+	Labels labels.Selector
+	Fields fields.Selector
+}
+type WatchRestrictions struct {
+	Labels          labels.Selector
+	Fields          fields.Selector
+	ResourceVersion string
+}
+
+type Action interface {
+	GetNamespace() string
+	GetVerb() string
+	GetResource() schema.GroupVersionResource
+	GetSubresource() string
+	Matches(verb, resource string) bool
+
+	// DeepCopy is used to copy an action to avoid any risk of accidental mutation.  Most people never need to call this
+	// because the invocation logic deep copies before calls to storage and reactors.
+	DeepCopy() Action
+}
+
+type GenericAction interface {
+	Action
+	GetValue() interface{}
+}
+
+type GetAction interface {
+	Action
+	GetName() string
+}
+
+type ListAction interface {
+	Action
+	GetListRestrictions() ListRestrictions
+}
+
+type CreateAction interface {
+	Action
+	GetObject() runtime.Object
+}
+
+type UpdateAction interface {
+	Action
+	GetObject() runtime.Object
+}
+
+type DeleteAction interface {
+	Action
+	GetName() string
+}
+
+type DeleteCollectionAction interface {
+	Action
+	GetListRestrictions() ListRestrictions
+}
+
+type PatchAction interface {
+	Action
+	GetName() string
+	GetPatchType() types.PatchType
+	GetPatch() []byte
+}
+
+type WatchAction interface {
+	Action
+	GetWatchRestrictions() WatchRestrictions
+}
+
+type ProxyGetAction interface {
+	Action
+	GetScheme() string
+	GetName() string
+	GetPort() string
+	GetPath() string
+	GetParams() map[string]string
+}
+
+type ActionImpl struct {
+	Namespace   string
+	Verb        string
+	Resource    schema.GroupVersionResource
+	Subresource string
+}
+
+func (a ActionImpl) GetNamespace() string {
+	return a.Namespace
+}
+func (a ActionImpl) GetVerb() string {
+	return a.Verb
+}
+func (a ActionImpl) GetResource() schema.GroupVersionResource {
+	return a.Resource
+}
+func (a ActionImpl) GetSubresource() string {
+	return a.Subresource
+}
+func (a ActionImpl) Matches(verb, resource string) bool {
+	return strings.ToLower(verb) == strings.ToLower(a.Verb) &&
+		strings.ToLower(resource) == strings.ToLower(a.Resource.Resource)
+}
+func (a ActionImpl) DeepCopy() Action {
+	ret := a
+	return ret
+}
+
+type GenericActionImpl struct {
+	ActionImpl
+	Value interface{}
+}
+
+func (a GenericActionImpl) GetValue() interface{} {
+	return a.Value
+}
+
+func (a GenericActionImpl) DeepCopy() Action {
+	return GenericActionImpl{
+		ActionImpl: a.ActionImpl.DeepCopy().(ActionImpl),
+		// TODO this is wrong, but no worse than before
+		Value: a.Value,
+	}
+}
+
+type GetActionImpl struct {
+	ActionImpl
+	Name string
+}
+
+func (a GetActionImpl) GetName() string {
+	return a.Name
+}
+
+func (a GetActionImpl) DeepCopy() Action {
+	return GetActionImpl{
+		ActionImpl: a.ActionImpl.DeepCopy().(ActionImpl),
+		Name:       a.Name,
+	}
+}
+
+type ListActionImpl struct {
+	ActionImpl
+	Kind             schema.GroupVersionKind
+	Name             string
+	ListRestrictions ListRestrictions
+}
+
+func (a ListActionImpl) GetKind() schema.GroupVersionKind {
+	return a.Kind
+}
+
+func (a ListActionImpl) GetListRestrictions() ListRestrictions {
+	return a.ListRestrictions
+}
+
+func (a ListActionImpl) DeepCopy() Action {
+	return ListActionImpl{
+		ActionImpl: a.ActionImpl.DeepCopy().(ActionImpl),
+		Kind:       a.Kind,
+		Name:       a.Name,
+		ListRestrictions: ListRestrictions{
+			Labels: a.ListRestrictions.Labels.DeepCopySelector(),
+			Fields: a.ListRestrictions.Fields.DeepCopySelector(),
+		},
+	}
+}
+
+type CreateActionImpl struct {
+	ActionImpl
+	Name   string
+	Object runtime.Object
+}
+
+func (a CreateActionImpl) GetObject() runtime.Object {
+	return a.Object
+}
+
+func (a CreateActionImpl) DeepCopy() Action {
+	return CreateActionImpl{
+		ActionImpl: a.ActionImpl.DeepCopy().(ActionImpl),
+		Name:       a.Name,
+		Object:     a.Object.DeepCopyObject(),
+	}
+}
+
+type UpdateActionImpl struct {
+	ActionImpl
+	Object runtime.Object
+}
+
+func (a UpdateActionImpl) GetObject() runtime.Object {
+	return a.Object
+}
+
+func (a UpdateActionImpl) DeepCopy() Action {
+	return UpdateActionImpl{
+		ActionImpl: a.ActionImpl.DeepCopy().(ActionImpl),
+		Object:     a.Object.DeepCopyObject(),
+	}
+}
+
+type PatchActionImpl struct {
+	ActionImpl
+	Name      string
+	PatchType types.PatchType
+	Patch     []byte
+}
+
+func (a PatchActionImpl) GetName() string {
+	return a.Name
+}
+
+func (a PatchActionImpl) GetPatch() []byte {
+	return a.Patch
+}
+
+func (a PatchActionImpl) GetPatchType() types.PatchType {
+	return a.PatchType
+}
+
+func (a PatchActionImpl) DeepCopy() Action {
+	patch := make([]byte, len(a.Patch))
+	copy(patch, a.Patch)
+	return PatchActionImpl{
+		ActionImpl: a.ActionImpl.DeepCopy().(ActionImpl),
+		Name:       a.Name,
+		PatchType:  a.PatchType,
+		Patch:      patch,
+	}
+}
+
+type DeleteActionImpl struct {
+	ActionImpl
+	Name string
+}
+
+func (a DeleteActionImpl) GetName() string {
+	return a.Name
+}
+
+func (a DeleteActionImpl) DeepCopy() Action {
+	return DeleteActionImpl{
+		ActionImpl: a.ActionImpl.DeepCopy().(ActionImpl),
+		Name:       a.Name,
+	}
+}
+
+type DeleteCollectionActionImpl struct {
+	ActionImpl
+	ListRestrictions ListRestrictions
+}
+
+func (a DeleteCollectionActionImpl) GetListRestrictions() ListRestrictions {
+	return a.ListRestrictions
+}
+
+func (a DeleteCollectionActionImpl) DeepCopy() Action {
+	return DeleteCollectionActionImpl{
+		ActionImpl: a.ActionImpl.DeepCopy().(ActionImpl),
+		ListRestrictions: ListRestrictions{
+			Labels: a.ListRestrictions.Labels.DeepCopySelector(),
+			Fields: a.ListRestrictions.Fields.DeepCopySelector(),
+		},
+	}
+}
+
+type WatchActionImpl struct {
+	ActionImpl
+	WatchRestrictions WatchRestrictions
+}
+
+func (a WatchActionImpl) GetWatchRestrictions() WatchRestrictions {
+	return a.WatchRestrictions
+}
+
+func (a WatchActionImpl) DeepCopy() Action {
+	return WatchActionImpl{
+		ActionImpl: a.ActionImpl.DeepCopy().(ActionImpl),
+		WatchRestrictions: WatchRestrictions{
+			Labels:          a.WatchRestrictions.Labels.DeepCopySelector(),
+			Fields:          a.WatchRestrictions.Fields.DeepCopySelector(),
+			ResourceVersion: a.WatchRestrictions.ResourceVersion,
+		},
+	}
+}
+
+type ProxyGetActionImpl struct {
+	ActionImpl
+	Scheme string
+	Name   string
+	Port   string
+	Path   string
+	Params map[string]string
+}
+
+func (a ProxyGetActionImpl) GetScheme() string {
+	return a.Scheme
+}
+
+func (a ProxyGetActionImpl) GetName() string {
+	return a.Name
+}
+
+func (a ProxyGetActionImpl) GetPort() string {
+	return a.Port
+}
+
+func (a ProxyGetActionImpl) GetPath() string {
+	return a.Path
+}
+
+func (a ProxyGetActionImpl) GetParams() map[string]string {
+	return a.Params
+}
+
+func (a ProxyGetActionImpl) DeepCopy() Action {
+	params := map[string]string{}
+	for k, v := range a.Params {
+		params[k] = v
+	}
+	return ProxyGetActionImpl{
+		ActionImpl: a.ActionImpl.DeepCopy().(ActionImpl),
+		Scheme:     a.Scheme,
+		Name:       a.Name,
+		Port:       a.Port,
+		Path:       a.Path,
+		Params:     params,
+	}
+}

--- a/vendor/k8s.io/client-go/testing/fake.go
+++ b/vendor/k8s.io/client-go/testing/fake.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	restclient "k8s.io/client-go/rest"
+)
+
+// Fake implements client.Interface. Meant to be embedded into a struct to get
+// a default implementation. This makes faking out just the method you want to
+// test easier.
+type Fake struct {
+	sync.RWMutex
+	actions []Action // these may be castable to other types, but "Action" is the minimum
+
+	// ReactionChain is the list of reactors that will be attempted for every
+	// request in the order they are tried.
+	ReactionChain []Reactor
+	// WatchReactionChain is the list of watch reactors that will be attempted
+	// for every request in the order they are tried.
+	WatchReactionChain []WatchReactor
+	// ProxyReactionChain is the list of proxy reactors that will be attempted
+	// for every request in the order they are tried.
+	ProxyReactionChain []ProxyReactor
+
+	Resources []*metav1.APIResourceList
+}
+
+// Reactor is an interface to allow the composition of reaction functions.
+type Reactor interface {
+	// Handles indicates whether or not this Reactor deals with a given
+	// action.
+	Handles(action Action) bool
+	// React handles the action and returns results.  It may choose to
+	// delegate by indicated handled=false.
+	React(action Action) (handled bool, ret runtime.Object, err error)
+}
+
+// WatchReactor is an interface to allow the composition of watch functions.
+type WatchReactor interface {
+	// Handles indicates whether or not this Reactor deals with a given
+	// action.
+	Handles(action Action) bool
+	// React handles a watch action and returns results.  It may choose to
+	// delegate by indicating handled=false.
+	React(action Action) (handled bool, ret watch.Interface, err error)
+}
+
+// ProxyReactor is an interface to allow the composition of proxy get
+// functions.
+type ProxyReactor interface {
+	// Handles indicates whether or not this Reactor deals with a given
+	// action.
+	Handles(action Action) bool
+	// React handles a watch action and returns results.  It may choose to
+	// delegate by indicating handled=false.
+	React(action Action) (handled bool, ret restclient.ResponseWrapper, err error)
+}
+
+// ReactionFunc is a function that returns an object or error for a given
+// Action.  If "handled" is false, then the test client will ignore the
+// results and continue to the next ReactionFunc.  A ReactionFunc can describe
+// reactions on subresources by testing the result of the action's
+// GetSubresource() method.
+type ReactionFunc func(action Action) (handled bool, ret runtime.Object, err error)
+
+// WatchReactionFunc is a function that returns a watch interface.  If
+// "handled" is false, then the test client will ignore the results and
+// continue to the next ReactionFunc.
+type WatchReactionFunc func(action Action) (handled bool, ret watch.Interface, err error)
+
+// ProxyReactionFunc is a function that returns a ResponseWrapper interface
+// for a given Action.  If "handled" is false, then the test client will
+// ignore the results and continue to the next ProxyReactionFunc.
+type ProxyReactionFunc func(action Action) (handled bool, ret restclient.ResponseWrapper, err error)
+
+// AddReactor appends a reactor to the end of the chain.
+func (c *Fake) AddReactor(verb, resource string, reaction ReactionFunc) {
+	c.ReactionChain = append(c.ReactionChain, &SimpleReactor{verb, resource, reaction})
+}
+
+// PrependReactor adds a reactor to the beginning of the chain.
+func (c *Fake) PrependReactor(verb, resource string, reaction ReactionFunc) {
+	c.ReactionChain = append([]Reactor{&SimpleReactor{verb, resource, reaction}}, c.ReactionChain...)
+}
+
+// AddWatchReactor appends a reactor to the end of the chain.
+func (c *Fake) AddWatchReactor(resource string, reaction WatchReactionFunc) {
+	c.WatchReactionChain = append(c.WatchReactionChain, &SimpleWatchReactor{resource, reaction})
+}
+
+// PrependWatchReactor adds a reactor to the beginning of the chain.
+func (c *Fake) PrependWatchReactor(resource string, reaction WatchReactionFunc) {
+	c.WatchReactionChain = append([]WatchReactor{&SimpleWatchReactor{resource, reaction}}, c.WatchReactionChain...)
+}
+
+// AddProxyReactor appends a reactor to the end of the chain.
+func (c *Fake) AddProxyReactor(resource string, reaction ProxyReactionFunc) {
+	c.ProxyReactionChain = append(c.ProxyReactionChain, &SimpleProxyReactor{resource, reaction})
+}
+
+// PrependProxyReactor adds a reactor to the beginning of the chain.
+func (c *Fake) PrependProxyReactor(resource string, reaction ProxyReactionFunc) {
+	c.ProxyReactionChain = append([]ProxyReactor{&SimpleProxyReactor{resource, reaction}}, c.ProxyReactionChain...)
+}
+
+// Invokes records the provided Action and then invokes the ReactionFunc that
+// handles the action if one exists. defaultReturnObj is expected to be of the
+// same type a normal call would return.
+func (c *Fake) Invokes(action Action, defaultReturnObj runtime.Object) (runtime.Object, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	actionCopy := action.DeepCopy()
+	c.actions = append(c.actions, action.DeepCopy())
+	for _, reactor := range c.ReactionChain {
+		if !reactor.Handles(actionCopy) {
+			continue
+		}
+
+		handled, ret, err := reactor.React(actionCopy)
+		if !handled {
+			continue
+		}
+
+		return ret, err
+	}
+
+	return defaultReturnObj, nil
+}
+
+// InvokesWatch records the provided Action and then invokes the ReactionFunc
+// that handles the action if one exists.
+func (c *Fake) InvokesWatch(action Action) (watch.Interface, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	actionCopy := action.DeepCopy()
+	c.actions = append(c.actions, action.DeepCopy())
+	for _, reactor := range c.WatchReactionChain {
+		if !reactor.Handles(actionCopy) {
+			continue
+		}
+
+		handled, ret, err := reactor.React(actionCopy)
+		if !handled {
+			continue
+		}
+
+		return ret, err
+	}
+
+	return nil, fmt.Errorf("unhandled watch: %#v", action)
+}
+
+// InvokesProxy records the provided Action and then invokes the ReactionFunc
+// that handles the action if one exists.
+func (c *Fake) InvokesProxy(action Action) restclient.ResponseWrapper {
+	c.Lock()
+	defer c.Unlock()
+
+	actionCopy := action.DeepCopy()
+	c.actions = append(c.actions, action.DeepCopy())
+	for _, reactor := range c.ProxyReactionChain {
+		if !reactor.Handles(actionCopy) {
+			continue
+		}
+
+		handled, ret, err := reactor.React(actionCopy)
+		if !handled || err != nil {
+			continue
+		}
+
+		return ret
+	}
+
+	return nil
+}
+
+// ClearActions clears the history of actions called on the fake client.
+func (c *Fake) ClearActions() {
+	c.Lock()
+	defer c.Unlock()
+
+	c.actions = make([]Action, 0)
+}
+
+// Actions returns a chronologically ordered slice fake actions called on the
+// fake client.
+func (c *Fake) Actions() []Action {
+	c.RLock()
+	defer c.RUnlock()
+	fa := make([]Action, len(c.actions))
+	copy(fa, c.actions)
+	return fa
+}

--- a/vendor/k8s.io/client-go/testing/fixture.go
+++ b/vendor/k8s.io/client-go/testing/fixture.go
@@ -1,0 +1,557 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"sync"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/watch"
+	restclient "k8s.io/client-go/rest"
+)
+
+// ObjectTracker keeps track of objects. It is intended to be used to
+// fake calls to a server by returning objects based on their kind,
+// namespace and name.
+type ObjectTracker interface {
+	// Add adds an object to the tracker. If object being added
+	// is a list, its items are added separately.
+	Add(obj runtime.Object) error
+
+	// Get retrieves the object by its kind, namespace and name.
+	Get(gvr schema.GroupVersionResource, ns, name string) (runtime.Object, error)
+
+	// Create adds an object to the tracker in the specified namespace.
+	Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error
+
+	// Update updates an existing object in the tracker in the specified namespace.
+	Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error
+
+	// List retrieves all objects of a given kind in the given
+	// namespace. Only non-List kinds are accepted.
+	List(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, ns string) (runtime.Object, error)
+
+	// Delete deletes an existing object from the tracker. If object
+	// didn't exist in the tracker prior to deletion, Delete returns
+	// no error.
+	Delete(gvr schema.GroupVersionResource, ns, name string) error
+
+	// Watch watches objects from the tracker. Watch returns a channel
+	// which will push added / modified / deleted object.
+	Watch(gvr schema.GroupVersionResource, ns string) (watch.Interface, error)
+}
+
+// ObjectScheme abstracts the implementation of common operations on objects.
+type ObjectScheme interface {
+	runtime.ObjectCreater
+	runtime.ObjectTyper
+}
+
+// ObjectReaction returns a ReactionFunc that applies core.Action to
+// the given tracker.
+func ObjectReaction(tracker ObjectTracker) ReactionFunc {
+	return func(action Action) (bool, runtime.Object, error) {
+		ns := action.GetNamespace()
+		gvr := action.GetResource()
+		// Here and below we need to switch on implementation types,
+		// not on interfaces, as some interfaces are identical
+		// (e.g. UpdateAction and CreateAction), so if we use them,
+		// updates and creates end up matching the same case branch.
+		switch action := action.(type) {
+
+		case ListActionImpl:
+			obj, err := tracker.List(gvr, action.GetKind(), ns)
+			return true, obj, err
+
+		case GetActionImpl:
+			obj, err := tracker.Get(gvr, ns, action.GetName())
+			return true, obj, err
+
+		case CreateActionImpl:
+			objMeta, err := meta.Accessor(action.GetObject())
+			if err != nil {
+				return true, nil, err
+			}
+			if action.GetSubresource() == "" {
+				err = tracker.Create(gvr, action.GetObject(), ns)
+			} else {
+				// TODO: Currently we're handling subresource creation as an update
+				// on the enclosing resource. This works for some subresources but
+				// might not be generic enough.
+				err = tracker.Update(gvr, action.GetObject(), ns)
+			}
+			if err != nil {
+				return true, nil, err
+			}
+			obj, err := tracker.Get(gvr, ns, objMeta.GetName())
+			return true, obj, err
+
+		case UpdateActionImpl:
+			objMeta, err := meta.Accessor(action.GetObject())
+			if err != nil {
+				return true, nil, err
+			}
+			err = tracker.Update(gvr, action.GetObject(), ns)
+			if err != nil {
+				return true, nil, err
+			}
+			obj, err := tracker.Get(gvr, ns, objMeta.GetName())
+			return true, obj, err
+
+		case DeleteActionImpl:
+			err := tracker.Delete(gvr, ns, action.GetName())
+			if err != nil {
+				return true, nil, err
+			}
+			return true, nil, nil
+
+		case PatchActionImpl:
+			obj, err := tracker.Get(gvr, ns, action.GetName())
+			if err != nil {
+				return true, nil, err
+			}
+
+			old, err := json.Marshal(obj)
+			if err != nil {
+				return true, nil, err
+			}
+
+			switch action.GetPatchType() {
+			case types.JSONPatchType:
+				patch, err := jsonpatch.DecodePatch(action.GetPatch())
+				if err != nil {
+					return true, nil, err
+				}
+				modified, err := patch.Apply(old)
+				if err != nil {
+					return true, nil, err
+				}
+				if err = json.Unmarshal(modified, obj); err != nil {
+					return true, nil, err
+				}
+			case types.MergePatchType:
+				modified, err := jsonpatch.MergePatch(old, action.GetPatch())
+				if err != nil {
+					return true, nil, err
+				}
+
+				if err := json.Unmarshal(modified, obj); err != nil {
+					return true, nil, err
+				}
+			case types.StrategicMergePatchType:
+				mergedByte, err := strategicpatch.StrategicMergePatch(old, action.GetPatch(), obj)
+				if err != nil {
+					return true, nil, err
+				}
+				if err = json.Unmarshal(mergedByte, obj); err != nil {
+					return true, nil, err
+				}
+			default:
+				return true, nil, fmt.Errorf("PatchType is not supported")
+			}
+
+			if err = tracker.Update(gvr, obj, ns); err != nil {
+				return true, nil, err
+			}
+
+			return true, obj, nil
+
+		default:
+			return false, nil, fmt.Errorf("no reaction implemented for %s", action)
+		}
+	}
+}
+
+type tracker struct {
+	scheme  ObjectScheme
+	decoder runtime.Decoder
+	lock    sync.RWMutex
+	objects map[schema.GroupVersionResource][]runtime.Object
+	// The value type of watchers is a map of which the key is either a namespace or
+	// all/non namespace aka "" and its value is list of fake watchers.
+	// Manipulations on resources will broadcast the notification events into the
+	// watchers' channel. Note that too many unhandled events (currently 100,
+	// see apimachinery/pkg/watch.DefaultChanSize) will cause a panic.
+	watchers map[schema.GroupVersionResource]map[string][]*watch.RaceFreeFakeWatcher
+}
+
+var _ ObjectTracker = &tracker{}
+
+// NewObjectTracker returns an ObjectTracker that can be used to keep track
+// of objects for the fake clientset. Mostly useful for unit tests.
+func NewObjectTracker(scheme ObjectScheme, decoder runtime.Decoder) ObjectTracker {
+	return &tracker{
+		scheme:   scheme,
+		decoder:  decoder,
+		objects:  make(map[schema.GroupVersionResource][]runtime.Object),
+		watchers: make(map[schema.GroupVersionResource]map[string][]*watch.RaceFreeFakeWatcher),
+	}
+}
+
+func (t *tracker) List(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, ns string) (runtime.Object, error) {
+	// Heuristic for list kind: original kind + List suffix. Might
+	// not always be true but this tracker has a pretty limited
+	// understanding of the actual API model.
+	listGVK := gvk
+	listGVK.Kind = listGVK.Kind + "List"
+	// GVK does have the concept of "internal version". The scheme recognizes
+	// the runtime.APIVersionInternal, but not the empty string.
+	if listGVK.Version == "" {
+		listGVK.Version = runtime.APIVersionInternal
+	}
+
+	list, err := t.scheme.New(listGVK)
+	if err != nil {
+		return nil, err
+	}
+
+	if !meta.IsListType(list) {
+		return nil, fmt.Errorf("%q is not a list type", listGVK.Kind)
+	}
+
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	objs, ok := t.objects[gvr]
+	if !ok {
+		return list, nil
+	}
+
+	matchingObjs, err := filterByNamespaceAndName(objs, ns, "")
+	if err != nil {
+		return nil, err
+	}
+	if err := meta.SetList(list, matchingObjs); err != nil {
+		return nil, err
+	}
+	return list.DeepCopyObject(), nil
+}
+
+func (t *tracker) Watch(gvr schema.GroupVersionResource, ns string) (watch.Interface, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	fakewatcher := watch.NewRaceFreeFake()
+
+	if _, exists := t.watchers[gvr]; !exists {
+		t.watchers[gvr] = make(map[string][]*watch.RaceFreeFakeWatcher)
+	}
+	t.watchers[gvr][ns] = append(t.watchers[gvr][ns], fakewatcher)
+	return fakewatcher, nil
+}
+
+func (t *tracker) Get(gvr schema.GroupVersionResource, ns, name string) (runtime.Object, error) {
+	errNotFound := errors.NewNotFound(gvr.GroupResource(), name)
+
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	objs, ok := t.objects[gvr]
+	if !ok {
+		return nil, errNotFound
+	}
+
+	matchingObjs, err := filterByNamespaceAndName(objs, ns, name)
+	if err != nil {
+		return nil, err
+	}
+	if len(matchingObjs) == 0 {
+		return nil, errNotFound
+	}
+	if len(matchingObjs) > 1 {
+		return nil, fmt.Errorf("more than one object matched gvr %s, ns: %q name: %q", gvr, ns, name)
+	}
+
+	// Only one object should match in the tracker if it works
+	// correctly, as Add/Update methods enforce kind/namespace/name
+	// uniqueness.
+	obj := matchingObjs[0].DeepCopyObject()
+	if status, ok := obj.(*metav1.Status); ok {
+		if status.Status != metav1.StatusSuccess {
+			return nil, &errors.StatusError{ErrStatus: *status}
+		}
+	}
+
+	return obj, nil
+}
+
+func (t *tracker) Add(obj runtime.Object) error {
+	if meta.IsListType(obj) {
+		return t.addList(obj, false)
+	}
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	gvks, _, err := t.scheme.ObjectKinds(obj)
+	if err != nil {
+		return err
+	}
+	if len(gvks) == 0 {
+		return fmt.Errorf("no registered kinds for %v", obj)
+	}
+	for _, gvk := range gvks {
+		// NOTE: UnsafeGuessKindToResource is a heuristic and default match. The
+		// actual registration in apiserver can specify arbitrary route for a
+		// gvk. If a test uses such objects, it cannot preset the tracker with
+		// objects via Add(). Instead, it should trigger the Create() function
+		// of the tracker, where an arbitrary gvr can be specified.
+		gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+		// Resource doesn't have the concept of "__internal" version, just set it to "".
+		if gvr.Version == runtime.APIVersionInternal {
+			gvr.Version = ""
+		}
+
+		err := t.add(gvr, obj, objMeta.GetNamespace(), false)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *tracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	return t.add(gvr, obj, ns, false)
+}
+
+func (t *tracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	return t.add(gvr, obj, ns, true)
+}
+
+func (t *tracker) getWatches(gvr schema.GroupVersionResource, ns string) []*watch.RaceFreeFakeWatcher {
+	watches := []*watch.RaceFreeFakeWatcher{}
+	if t.watchers[gvr] != nil {
+		if w := t.watchers[gvr][ns]; w != nil {
+			watches = append(watches, w...)
+		}
+		if ns != metav1.NamespaceAll {
+			if w := t.watchers[gvr][metav1.NamespaceAll]; w != nil {
+				watches = append(watches, w...)
+			}
+		}
+	}
+	return watches
+}
+
+func (t *tracker) add(gvr schema.GroupVersionResource, obj runtime.Object, ns string, replaceExisting bool) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	gr := gvr.GroupResource()
+
+	// To avoid the object from being accidentally modified by caller
+	// after it's been added to the tracker, we always store the deep
+	// copy.
+	obj = obj.DeepCopyObject()
+
+	newMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	// Propagate namespace to the new object if hasn't already been set.
+	if len(newMeta.GetNamespace()) == 0 {
+		newMeta.SetNamespace(ns)
+	}
+
+	if ns != newMeta.GetNamespace() {
+		msg := fmt.Sprintf("request namespace does not match object namespace, request: %q object: %q", ns, newMeta.GetNamespace())
+		return errors.NewBadRequest(msg)
+	}
+
+	for i, existingObj := range t.objects[gvr] {
+		oldMeta, err := meta.Accessor(existingObj)
+		if err != nil {
+			return err
+		}
+		if oldMeta.GetNamespace() == newMeta.GetNamespace() && oldMeta.GetName() == newMeta.GetName() {
+			if replaceExisting {
+				for _, w := range t.getWatches(gvr, ns) {
+					w.Modify(obj)
+				}
+				t.objects[gvr][i] = obj
+				return nil
+			}
+			return errors.NewAlreadyExists(gr, newMeta.GetName())
+		}
+	}
+
+	if replaceExisting {
+		// Tried to update but no matching object was found.
+		return errors.NewNotFound(gr, newMeta.GetName())
+	}
+
+	t.objects[gvr] = append(t.objects[gvr], obj)
+
+	for _, w := range t.getWatches(gvr, ns) {
+		w.Add(obj)
+	}
+
+	return nil
+}
+
+func (t *tracker) addList(obj runtime.Object, replaceExisting bool) error {
+	list, err := meta.ExtractList(obj)
+	if err != nil {
+		return err
+	}
+	errs := runtime.DecodeList(list, t.decoder)
+	if len(errs) > 0 {
+		return errs[0]
+	}
+	for _, obj := range list {
+		if err := t.Add(obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *tracker) Delete(gvr schema.GroupVersionResource, ns, name string) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	found := false
+
+	for i, existingObj := range t.objects[gvr] {
+		objMeta, err := meta.Accessor(existingObj)
+		if err != nil {
+			return err
+		}
+		if objMeta.GetNamespace() == ns && objMeta.GetName() == name {
+			obj := t.objects[gvr][i]
+			t.objects[gvr] = append(t.objects[gvr][:i], t.objects[gvr][i+1:]...)
+			for _, w := range t.getWatches(gvr, ns) {
+				w.Delete(obj)
+			}
+			found = true
+			break
+		}
+	}
+
+	if found {
+		return nil
+	}
+
+	return errors.NewNotFound(gvr.GroupResource(), name)
+}
+
+// filterByNamespaceAndName returns all objects in the collection that
+// match provided namespace and name. Empty namespace matches
+// non-namespaced objects.
+func filterByNamespaceAndName(objs []runtime.Object, ns, name string) ([]runtime.Object, error) {
+	var res []runtime.Object
+
+	for _, obj := range objs {
+		acc, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		if ns != "" && acc.GetNamespace() != ns {
+			continue
+		}
+		if name != "" && acc.GetName() != name {
+			continue
+		}
+		res = append(res, obj)
+	}
+
+	return res, nil
+}
+
+func DefaultWatchReactor(watchInterface watch.Interface, err error) WatchReactionFunc {
+	return func(action Action) (bool, watch.Interface, error) {
+		return true, watchInterface, err
+	}
+}
+
+// SimpleReactor is a Reactor.  Each reaction function is attached to a given verb,resource tuple.  "*" in either field matches everything for that value.
+// For instance, *,pods matches all verbs on pods.  This allows for easier composition of reaction functions
+type SimpleReactor struct {
+	Verb     string
+	Resource string
+
+	Reaction ReactionFunc
+}
+
+func (r *SimpleReactor) Handles(action Action) bool {
+	verbCovers := r.Verb == "*" || r.Verb == action.GetVerb()
+	if !verbCovers {
+		return false
+	}
+	resourceCovers := r.Resource == "*" || r.Resource == action.GetResource().Resource
+	if !resourceCovers {
+		return false
+	}
+
+	return true
+}
+
+func (r *SimpleReactor) React(action Action) (bool, runtime.Object, error) {
+	return r.Reaction(action)
+}
+
+// SimpleWatchReactor is a WatchReactor.  Each reaction function is attached to a given resource.  "*" matches everything for that value.
+// For instance, *,pods matches all verbs on pods.  This allows for easier composition of reaction functions
+type SimpleWatchReactor struct {
+	Resource string
+
+	Reaction WatchReactionFunc
+}
+
+func (r *SimpleWatchReactor) Handles(action Action) bool {
+	resourceCovers := r.Resource == "*" || r.Resource == action.GetResource().Resource
+	if !resourceCovers {
+		return false
+	}
+
+	return true
+}
+
+func (r *SimpleWatchReactor) React(action Action) (bool, watch.Interface, error) {
+	return r.Reaction(action)
+}
+
+// SimpleProxyReactor is a ProxyReactor.  Each reaction function is attached to a given resource.  "*" matches everything for that value.
+// For instance, *,pods matches all verbs on pods.  This allows for easier composition of reaction functions.
+type SimpleProxyReactor struct {
+	Resource string
+
+	Reaction ProxyReactionFunc
+}
+
+func (r *SimpleProxyReactor) Handles(action Action) bool {
+	resourceCovers := r.Resource == "*" || r.Resource == action.GetResource().Resource
+	if !resourceCovers {
+		return false
+	}
+
+	return true
+}
+
+func (r *SimpleProxyReactor) React(action Action) (bool, restclient.ResponseWrapper, error) {
+	return r.Reaction(action)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -284,6 +284,7 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v11.0.0+incompatible => k8s.io/client-go v0.0.0-20190918200256-06eb1244587a
 k8s.io/client-go/discovery
+k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
 k8s.io/client-go/informers
 k8s.io/client-go/informers/admissionregistration
@@ -419,6 +420,7 @@ k8s.io/client-go/plugin/pkg/client/auth/openstack
 k8s.io/client-go/rest
 k8s.io/client-go/rest/watch
 k8s.io/client-go/restmapper
+k8s.io/client-go/testing
 k8s.io/client-go/third_party/forked/golang/template
 k8s.io/client-go/tools/auth
 k8s.io/client-go/tools/cache
@@ -467,6 +469,7 @@ sigs.k8s.io/controller-runtime/pkg/cache/internal
 sigs.k8s.io/controller-runtime/pkg/client
 sigs.k8s.io/controller-runtime/pkg/client/apiutil
 sigs.k8s.io/controller-runtime/pkg/client/config
+sigs.k8s.io/controller-runtime/pkg/client/fake
 sigs.k8s.io/controller-runtime/pkg/controller
 sigs.k8s.io/controller-runtime/pkg/controller/controllerutil
 sigs.k8s.io/controller-runtime/pkg/event
@@ -475,6 +478,7 @@ sigs.k8s.io/controller-runtime/pkg/healthz
 sigs.k8s.io/controller-runtime/pkg/internal/controller
 sigs.k8s.io/controller-runtime/pkg/internal/controller/metrics
 sigs.k8s.io/controller-runtime/pkg/internal/log
+sigs.k8s.io/controller-runtime/pkg/internal/objectutil
 sigs.k8s.io/controller-runtime/pkg/internal/recorder
 sigs.k8s.io/controller-runtime/pkg/leaderelection
 sigs.k8s.io/controller-runtime/pkg/log

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/internal/objectutil"
+)
+
+type fakeClient struct {
+	tracker testing.ObjectTracker
+	scheme  *runtime.Scheme
+}
+
+var _ client.Client = &fakeClient{}
+
+// NewFakeClient creates a new fake client for testing.
+// You can choose to initialize it with a slice of runtime.Object.
+// Deprecated: use NewFakeClientWithScheme.  You should always be
+// passing an explicit Scheme.
+func NewFakeClient(initObjs ...runtime.Object) client.Client {
+	return NewFakeClientWithScheme(scheme.Scheme, initObjs...)
+}
+
+// NewFakeClientWithScheme creates a new fake client with the given scheme
+// for testing.
+// You can choose to initialize it with a slice of runtime.Object.
+func NewFakeClientWithScheme(clientScheme *runtime.Scheme, initObjs ...runtime.Object) client.Client {
+	tracker := testing.NewObjectTracker(clientScheme, scheme.Codecs.UniversalDecoder())
+	for _, obj := range initObjs {
+		err := tracker.Add(obj)
+		if err != nil {
+			panic(fmt.Errorf("failed to add object %v to fake client: %v", obj, err))
+		}
+	}
+	return &fakeClient{
+		tracker: tracker,
+		scheme:  clientScheme,
+	}
+}
+
+func (c *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	o, err := c.tracker.Get(gvr, key.Namespace, key.Name)
+	if err != nil {
+		return err
+	}
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	_, _, err = decoder.Decode(j, nil, obj)
+	return err
+}
+
+func (c *fakeClient) List(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasSuffix(gvk.Kind, "List") {
+		return fmt.Errorf("non-list type %T (kind %q) passed as output", obj, gvk)
+	}
+	// we need the non-list GVK, so chop off the "List" from the end of the kind
+	gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	o, err := c.tracker.List(gvr, gvk, listOpts.Namespace)
+	if err != nil {
+		return err
+	}
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	_, _, err = decoder.Decode(j, nil, obj)
+	if err != nil {
+		return err
+	}
+
+	if listOpts.LabelSelector != nil {
+		objs, err := meta.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+		filteredObjs, err := objectutil.FilterWithLabels(objs, listOpts.LabelSelector)
+		if err != nil {
+			return err
+		}
+		err = meta.SetList(obj, filteredObjs)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *fakeClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+	createOptions := &client.CreateOptions{}
+	createOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range createOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	return c.tracker.Create(gvr, obj, accessor.GetNamespace())
+}
+
+func (c *fakeClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	delOptions := client.DeleteOptions{}
+	delOptions.ApplyOptions(opts)
+
+	//TODO: implement propagation
+	return c.tracker.Delete(gvr, accessor.GetNamespace(), accessor.GetName())
+}
+
+func (c *fakeClient) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
+	gvk, err := apiutil.GVKForObject(obj, scheme.Scheme)
+	if err != nil {
+		return err
+	}
+
+	dcOptions := client.DeleteAllOfOptions{}
+	dcOptions.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	o, err := c.tracker.List(gvr, gvk, dcOptions.Namespace)
+	if err != nil {
+		return err
+	}
+
+	objs, err := meta.ExtractList(o)
+	if err != nil {
+		return err
+	}
+	filteredObjs, err := objectutil.FilterWithLabels(objs, dcOptions.LabelSelector)
+	if err != nil {
+		return err
+	}
+	for _, o := range filteredObjs {
+		accessor, err := meta.Accessor(o)
+		if err != nil {
+			return err
+		}
+		err = c.tracker.Delete(gvr, accessor.GetNamespace(), accessor.GetName())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *fakeClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	updateOptions := &client.UpdateOptions{}
+	updateOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range updateOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	return c.tracker.Update(gvr, obj, accessor.GetNamespace())
+}
+
+func (c *fakeClient) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	patchOptions := &client.PatchOptions{}
+	patchOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range patchOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	reaction := testing.ObjectReaction(c.tracker)
+	handled, o, err := reaction(testing.NewPatchAction(gvr, accessor.GetNamespace(), accessor.GetName(), patch.Type(), data))
+	if err != nil {
+		return err
+	}
+	if !handled {
+		panic("tracker could not handle patch method")
+	}
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	_, _, err = decoder.Decode(j, nil, obj)
+	return err
+}
+
+func (c *fakeClient) Status() client.StatusWriter {
+	return &fakeStatusWriter{client: c}
+}
+
+func getGVRFromObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionResource, error) {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	return gvr, nil
+}
+
+type fakeStatusWriter struct {
+	client *fakeClient
+}
+
+func (sw *fakeStatusWriter) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	// TODO(droot): This results in full update of the obj (spec + status). Need
+	// a way to update status field only.
+	return sw.client.Update(ctx, obj, opts...)
+}
+
+func (sw *fakeStatusWriter) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	// TODO(droot): This results in full update of the obj (spec + status). Need
+	// a way to update status field only.
+	return sw.client.Patch(ctx, obj, patch, opts...)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/doc.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package fake provides a fake client for testing.
+
+An fake client is backed by its simple object store indexed by GroupVersionResource.
+You can create a fake client with optional objects.
+
+	client := NewFakeClient(initObjs...) // initObjs is a slice of runtime.Object
+
+You can invoke the methods defined in the Client interface.
+
+When it doubt, it's almost always better not to use this package and instead use
+envtest.Environment with a real client and API server.
+*/
+package fake

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/objectutil/filter.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/objectutil/filter.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectutil
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// FilterWithLabels returns a copy of the items in objs matching labelSel
+func FilterWithLabels(objs []runtime.Object, labelSel labels.Selector) ([]runtime.Object, error) {
+	outItems := make([]runtime.Object, 0, len(objs))
+	for _, obj := range objs {
+		meta, err := apimeta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		if labelSel != nil {
+			lbls := labels.Set(meta.GetLabels())
+			if !labelSel.Matches(lbls) {
+				continue
+			}
+		}
+		outItems = append(outItems, obj.DeepCopyObject())
+	}
+	return outItems, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Copies the unit tests and converts them to use runtime operator instead of appsody
- Includes tests for `utils`, `reconciler`, and `controller` packages.

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #4 
