### PR TITLE
Update scripts to point to correct module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
   - 1.13.x
 
 go_import_path: github.com/application-runtimes/operator
+env:
+  - GO111MODULE=on
 
 services:
   - docker

--- a/scripts/build-releases.sh
+++ b/scripts/build-releases.sh
@@ -83,7 +83,7 @@ build_release() {
     go build -o "$(pwd)/build/_output/bin/operator" \
       -gcflags all=-trimpath=$(pwd)/.. \
       -asmflags all=-trimpath=$(pwd)/..\
-      -mod=vendor "github.com/application-runtimes/operator"
+      -mod=vendor "github.com/application-runtimes/operator/cmd/manager"
 
     if [[ $? -ne 0 ]]; then
       echo "Failed to build binary for zLinux, exiting"


### PR DESCRIPTION
**What this PR does / why we need it?**:

- The manual operator build that is necessary on s390x is failing due to pointing to the incorrect main.go module
- Adds GO111MODULE=on to travis.yml environment variables.

